### PR TITLE
Simulator runs in Busybox

### DIFF
--- a/src/jcc/cli/sim.py
+++ b/src/jcc/cli/sim.py
@@ -57,13 +57,11 @@ def _start_simulator(sim_dir: Path, port: int) -> None:
     result = _docker(
         "run", "-d",
         "--name", CONTAINER_NAME,
-        "-v", f"{sim_dir}:/jcdk-sim:ro",
+        "-v", f"{sim_dir}/runtime/bin:/app:ro",
         "-p", f"{port}:9025",
         "jcdk-sim",
         "sh", "-c",
-        "LD_LIBRARY_PATH=/jcdk-sim/runtime/bin "
-        "OPENSSL_MODULES=/jcdk-sim/runtime/bin "
-        "/jcdk-sim/runtime/bin/jcsl -p=9025",
+        "LD_LIBRARY_PATH=/app OPENSSL_MODULES=/app /app/jcsl -p=9025",
     )
     if result.returncode != 0:
         print(f"Failed to start simulator:\n{result.stderr}", file=sys.stderr)

--- a/src/jcc/setup.py
+++ b/src/jcc/setup.py
@@ -16,9 +16,7 @@ ORACLE_URL = "https://www.oracle.com/java/technologies/javacard-downloads.html"
 GP_API = "https://api.github.com/repos/martinpaljak/GlobalPlatformPro/releases/latest"
 
 SIMULATOR_DOCKERFILE = (
-    "FROM --platform=linux/386 i386/debian:bookworm\n"
-    "RUN apt-get update && apt-get install -y --no-install-recommends socat "
-    "&& rm -rf /var/lib/apt/lists/*\n"
+    "FROM --platform=linux/386 i386/busybox:glibc\n"
 )
 
 G = "\033[32m"


### PR DESCRIPTION
Since we are talking Java Card (~200K EEPROM) and C, we probably share a taste for _small is beautiful_ and I realized that the simulator runs just fine in Busybox and doesn't need `socat`; it listens directly on `-p 9025`. Also, we just need to mount `/runtime/bin` in the container.

This shrinks the `jcdk-sim` image from 199MB to 7.29MB 🧹